### PR TITLE
Fix invalid example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 func main() {
     r := mux.NewRouter()
     r.HandleFunc("/", handler)
-    r.Methods("POST").HandleFunc("/products", handler)
-    r.Methods("GET").HandleFunc("/articles", handler)
-    r.Methods("GET", "PUT").HandleFunc("/articles/{id}", handler)
+    r.HandleFunc("/products", handler).Methods("POST")
+    r.HandleFunc("/articles", handler).Methods("GET")
+    r.HandleFunc("/articles/{id}", handler).Methods("GET", "PUT")
     r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
         t, err := route.GetPathTemplate()
         if err != nil {


### PR DESCRIPTION
In the "List Routes" example code, `.HandleFunc` was being called on a `*mux.Route` rather than `*mux.Router`. Updated the example code to work :)